### PR TITLE
Aggregate errors for downstream handling

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,1 @@
+/.project

--- a/Makefile
+++ b/Makefile
@@ -2,5 +2,5 @@
 include ../Makefile.deploytemplate
 
 TOOL_FOLDER_NAME=MzTabConverter
-WORKFLOW_VERSION=1.0
+WORKFLOW_VERSION=1.1
 WORKFLOW_LABEL="MzTab Converter"

--- a/tools/MzTabConverter/convert_result_file.sh
+++ b/tools/MzTabConverter/convert_result_file.sh
@@ -99,7 +99,7 @@ elif [[ "$lower_case_extension" == "mzid" || "$lower_case_extension" == "xml" ]]
     if [ $status -ne 0 ]; then
         echo "Conversion failed: converter returned exit code $status"
         if [ ! -z "$error_file" ]; then
-            echo "Result file [$input] could not be converted to mzTab format." > "$error_file"
+            echo "$filename: File could not be converted to mzTab format." > "$error_file"
         else
             exit 1
         fi
@@ -108,7 +108,7 @@ elif [[ "$lower_case_extension" == "mzid" || "$lower_case_extension" == "xml" ]]
 else
     echo "ERROR: Input file [$input] has unsupported format [.$extension]."
     if [ ! -z "$error_file" ]; then
-        echo "Result file [$input] has unsupported format [.$extension]." > "$error_file"
+        echo "$filename: File has unsupported format [.$extension]." > "$error_file"
     else
         exit 1
     fi

--- a/tools/MzTabConverter/convert_result_file.sh
+++ b/tools/MzTabConverter/convert_result_file.sh
@@ -44,7 +44,7 @@ extension="${filename##*.}"
 # set up error file
 unset error_file
 if [ ! -z "$errors" ]; then
-    error_file="$errors/$base.err"
+    error_file="$errors/$filename"
 fi
 # extract input file's collection directory
 collection=`readlink -f $input | xargs -I {} dirname "{}"`

--- a/tools/MzTabConverter/convert_result_file.sh
+++ b/tools/MzTabConverter/convert_result_file.sh
@@ -29,10 +29,23 @@ else
     exit 1
 fi
 
+# verify errors directory (optional)
+if [ $# -ge 3 ]; then
+    errors=${3%/}
+    if [ ! -d "$errors" ]; then
+        mkdir "$errors"
+    fi
+fi
+
 # extract input file's base name and extension
 filename="${input##*/}"
 base="${filename%.*}"
 extension="${filename##*.}"
+# set up error file
+unset error_file
+if [ ! -z "$errors" ]; then
+    error_file="$errors/$base.err"
+fi
 # extract input file's collection directory
 collection=`readlink -f $input | xargs -I {} dirname "{}"`
 # extract input file's top-level task directory
@@ -82,15 +95,23 @@ elif [[ "$lower_case_extension" == "mzid" || "$lower_case_extension" == "xml" ]]
     # remove scratch input file
     echo "Deleting scratch input file [$scratch_input]."
     rm "$scratch_input"
-    # if the conversion failed, pass that exit code
+    # if the conversion failed, report error
     if [ $status -ne 0 ]; then
         echo "Conversion failed: converter returned exit code $status"
-        exit $status
+        if [ ! -z "$error_file" ]; then
+            echo "Result file [$input] could not be converted to mzTab format." > "$error_file"
+        else
+            exit 1
+        fi
     fi
-# otherwise, input file is of an unsupported format, so fail
+# otherwise, input file is of an unsupported format, so report error
 else
     echo "ERROR: Input file [$input] has unsupported format [.$extension]."
-    exit 1
+    if [ ! -z "$error_file" ]; then
+        echo "Result file [$input] has unsupported format [.$extension]." > "$error_file"
+    else
+        exit 1
+    fi
 fi
 
 exit


### PR DESCRIPTION
Added an optional "errors" argument, which when specified will cause any errors to be written as files into the corresponding directory, to be aggregated and handled in a later step of the workflow.

Example (seen in this task's "1 result file failed pre-processing" error message): https://ccms-internal.ucsd.edu/ProteoSAFe/status.jsp?task=c2158d3d92e7478ab07767a3dfe81975